### PR TITLE
Revert removal of custom services

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,7 +1,6 @@
 name: HACS Action
 
 on:
-  push:
   pull_request:
 
 jobs:

--- a/custom_components/airscape/manifest.json
+++ b/custom_components/airscape/manifest.json
@@ -3,7 +3,7 @@
     "name": "Airscape Whole House Fan",
     "documentation": "https://www.home-assistant.io/components/fan.airscape",
     "issue_tracker": "https://github.com/quielb/hass-airscape/issues",
-    "version": "0.1.9.2",
+    "version": "0.1.9.3",
     "requirements": [
         "airscape==0.1.9.2"
     ],

--- a/custom_components/airscape/services.yaml
+++ b/custom_components/airscape/services.yaml
@@ -1,3 +1,19 @@
+speed_up:
+  name: Speed Up
+  description: Bump the WHF speed up by 1.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Entity ID of the fan to change.
+      required: true
+slow_down:
+  name: Slow Down
+  description: Bump the WHF speed down by 1.
+  fields:
+    entity_id:
+      name: Entity ID
+      description: Entity ID of the fan to change.
+      required: true
 add_time:
   name: Add Time
   description: Add an hour to the automatic shutoff timer of the WHF.

--- a/info.md
+++ b/info.md
@@ -13,7 +13,12 @@ A Home Assistant custom component to control Airscape Whole House Fans with Gen2
 
 ### Changes
 
-{% if version_installed.replace("v", "").replace(".","") | int < 190  %}
+{% if version_installed.replace("v", "").replace(".","") | int < 193  %}
+
+- Reverted the removal of custom services slow_down and speed_up. The built in service fan.decrease_speed allows the fan to be turned off
+  if decreased_speed is at the minimum speed.
+  {% endif %}
+  {% if version_installed.replace("v", "").replace(".","") | int < 190  %}
 
 - Added the ability to dynamically determine max speed based on model. Should allow for speed to be correctly represented in the Front End.
 - Updated Entity to utilized the new percentage speed model in HA.
@@ -43,10 +48,10 @@ fan:
 
 The minimum attribute is optional. It specifies the minimum starting speed and prevents the speed from going below that value.
 
-This component adds one custom service:
+This component adds three custom service:
 
 ```
+airscape.speed_up
+airscape.slow_down
 airscape.add_time
 ```
-
-This allows for adding an hour of time to the timer on the fan.


### PR DESCRIPTION
Reverted the removal of custom services `airscape.slow_down` and `airscape.speed_up`. The built in service `fan.decrease_speed` allows the fan to be turned off  if `fan.decreased_speed` is at the minimum speed.

Since my use case is to control the speed of the fan based on deltaT there would be a common occurrence of the fan getting turned off by `fan.decreased_speed` which would case the fan to cycle on and off all night.